### PR TITLE
Fix/timeseries generation

### DIFF
--- a/u8timeseries/tests/test_timeseries_generation.py
+++ b/u8timeseries/tests/test_timeseries_generation.py
@@ -6,7 +6,7 @@ from ..timeseries import TimeSeries
 from u8timeseries.utils.timeseries_generation import (
     constant_timeseries, 
     linear_timeseries, 
-    periodic_timeseries,
+    sine_timeseries,
     gaussian_timeseries, 
     random_walk_timeseries, 
     us_holiday_timeseries
@@ -38,7 +38,7 @@ class TimeSeriesGenerationTestCase(unittest.TestCase):
         self.assertEqual(linear_ts.values()[-1], end_value)
         self.assertAlmostEqual(linear_ts.values()[-1] - linear_ts.values()[-2], (end_value - start_value) / (length - 1))
 
-    def test_periodic_timeseries(self):
+    def test_sine_timeseries(self):
 
         # testing parameters
         length = 100
@@ -46,9 +46,9 @@ class TimeSeriesGenerationTestCase(unittest.TestCase):
         value_y_offset = -3
 
         # testing for correct value range
-        periodic_ts = periodic_timeseries(length=length, value_amplitude=value_amplitude, value_y_offset=value_y_offset)
-        self.assertTrue((periodic_ts <= value_y_offset + value_amplitude).all())
-        self.assertTrue((periodic_ts >= value_y_offset - value_amplitude).all())
+        sine_ts = sine_timeseries(length=length, value_amplitude=value_amplitude, value_y_offset=value_y_offset)
+        self.assertTrue((sine_ts <= value_y_offset + value_amplitude).all())
+        self.assertTrue((sine_ts >= value_y_offset - value_amplitude).all())
 
     def test_gaussian_timeseries(self):
 

--- a/u8timeseries/tests/test_timeseries_generation.py
+++ b/u8timeseries/tests/test_timeseries_generation.py
@@ -7,7 +7,7 @@ from u8timeseries.utils.timeseries_generation import (
     constant_timeseries, 
     linear_timeseries, 
     periodic_timeseries,
-    white_noise_timeseries, 
+    gaussian_timeseries, 
     random_walk_timeseries, 
     us_holiday_timeseries
 )
@@ -30,33 +30,34 @@ class TimeSeriesGenerationTestCase(unittest.TestCase):
         # testing parameters
         length = 100
         start_value = 5
-        value_delta = 3
+        end_value = 12
 
-        # testing for correct start and end values
-        linear_ts = linear_timeseries(start_value=start_value, value_delta=value_delta, length=length)
+        # testing for start value, end value and delta between two adjacent entries
+        linear_ts = linear_timeseries(start_value=start_value, end_value=end_value, length=length)
         self.assertEqual(linear_ts.values()[0], start_value)
-        self.assertEqual(linear_ts.values()[-1], start_value + (length - 1) * value_delta)
+        self.assertEqual(linear_ts.values()[-1], end_value)
+        self.assertAlmostEqual(linear_ts.values()[-1] - linear_ts.values()[-2], (end_value - start_value) / (length - 1))
 
     def test_periodic_timeseries(self):
 
         # testing parameters
         length = 100
-        amplitude = 5
-        y_offset = -3
+        value_amplitude = 5
+        value_y_offset = -3
 
         # testing for correct value range
-        periodic_ts = periodic_timeseries(length=length, amplitude=amplitude, y_offset=y_offset)
-        self.assertTrue((periodic_ts <= y_offset + amplitude).all())
-        self.assertTrue((periodic_ts >= y_offset - amplitude).all())
+        periodic_ts = periodic_timeseries(length=length, value_amplitude=value_amplitude, value_y_offset=value_y_offset)
+        self.assertTrue((periodic_ts <= value_y_offset + value_amplitude).all())
+        self.assertTrue((periodic_ts >= value_y_offset - value_amplitude).all())
 
-    def test_white_noise_timeseries(self):
+    def test_gaussian_timeseries(self):
 
         # testing parameters
         length = 100
 
         # testing for correct length
-        white_noise_ts = white_noise_timeseries(length=length)
-        self.assertEqual(len(white_noise_ts), length)
+        gaussian_ts = gaussian_timeseries(length=length)
+        self.assertEqual(len(gaussian_ts), length)
 
     def test_random_walk_timeseries(self):
 
@@ -71,9 +72,9 @@ class TimeSeriesGenerationTestCase(unittest.TestCase):
 
         # testing parameters
         length = 30
-        start_date = pd.Timestamp('20201201')
+        start_ts = pd.Timestamp('20201201')
 
         # testing for christmas and non-holiday
-        us_holiday_ts = us_holiday_timeseries(length=length, start_date=start_date)
+        us_holiday_ts = us_holiday_timeseries(length=length, start_ts=start_ts)
         self.assertEqual(us_holiday_ts._series.at[pd.Timestamp('20201225')], 1)
         self.assertEqual(us_holiday_ts._series.at[pd.Timestamp('20201210')], 0)

--- a/u8timeseries/utils/timeseries_generation.py
+++ b/u8timeseries/utils/timeseries_generation.py
@@ -111,9 +111,7 @@ def random_walk_timeseries(length: int = 10, freq: str = 'D', mean: float = 0, s
     """
 
     times = pd.date_range(periods=length, freq=freq, start=start_ts)
-    values = [np.random.normal(mean, std)]
-    while (len(values) < length):
-        values.append(values[-1] + np.random.normal(mean, std))
+    values = np.cumsum(np.random.normal(mean, std, size=length))
 
     return TimeSeries.from_times_and_values(times, values)
 

--- a/u8timeseries/utils/timeseries_generation.py
+++ b/u8timeseries/utils/timeseries_generation.py
@@ -87,8 +87,8 @@ def gaussian_timeseries(length: int = 10, freq: str = 'D', mean: Union[float, np
                  given, a different mean is used at each step.
     :param std: The standard deviation of the gaussian distribution that is sampled at each step.
                 If a float value is given, the same standard deviation is used at every step.
-                If a 'length' x 'length' numpy.ndarray of floats with the right dimensions is given,
-                it will be used as covariance matrix for a multivariate gaussian distribution.
+                If a 'length' x 'length' numpy.ndarray of floats  is given, it will
+                be used as covariance matrix for a multivariate gaussian distribution.
     :param length: The length of the returned TimeSeries.
     :param freq: The time difference between two adjacent entries in the returned TimeSeries. A DateOffset alias is expected.
     :param start_ts: The time index of the first entry in the returned TimeSeries.

--- a/u8timeseries/utils/timeseries_generation.py
+++ b/u8timeseries/utils/timeseries_generation.py
@@ -50,7 +50,7 @@ def linear_timeseries(start_value: float = 0, end_value: float = 1, length: int 
     return TimeSeries.from_times_and_values(times, values)
 
 
-def periodic_timeseries(value_frequency: float = 0.1, value_amplitude: float = 1, value_phase: float = 0, 
+def sine_timeseries(value_frequency: float = 0.1, value_amplitude: float = 1, value_phase: float = 0, 
                         value_y_offset: float = 0, length: int = 10, freq: str = 'D',
                         start_ts: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
     """

--- a/u8timeseries/utils/timeseries_generation.py
+++ b/u8timeseries/utils/timeseries_generation.py
@@ -9,91 +9,94 @@ from u8timeseries.timeseries import TimeSeries
 
 
 
-def constant_timeseries(value: float = 0, length: int = 10, offset: str = 'D',
-                        start_date: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
+def constant_timeseries(value: float = 1, length: int = 10, freq: str = 'D',
+                        start_ts: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
     """
-    Creates a constant TimeSeries with the given value, length, start date and offset.
+    Creates a constant TimeSeries with the given value, length, start date and frequency.
 
     :param value: The constant value that the TimeSeries object will assume at every index.
     :param length: The length of the returned TimeSeries.
-    :param offset: The time differene between two adjacent entries in the returned TimeSeries. A DateOffset alias is expected;
+    :param freq: The time difference between two adjacent entries in the returned TimeSeries. A DateOffset alias is expected;
                    see: https://pandas.pydata.org/pandas-docs/stable/user_guide/TimeSeries.html#dateoffset-objects.
-    :param start_date: The time index of the first entry in the returned TimeSeries.
+    :param start_ts: The time index of the first entry in the returned TimeSeries.
     :return: A constant TimeSeries with value 'value'.
     """
 
-    times = pd.date_range(periods=length, freq=offset, start=start_date)
+    times = pd.date_range(periods=length, freq=freq, start=start_ts)
     values = np.full(length, value)
 
     return TimeSeries.from_times_and_values(times, values)
 
 
-def linear_timeseries(start_value: float = 0, value_delta: float = 1, length: int = 10, offset: str = 'D',
-                      start_date: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
+def linear_timeseries(start_value: float = 0, end_value: float = 1, length: int = 10, freq: str = 'D',
+                      start_ts: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
     """
-    Creates a TimeSeries with a starting value of 'start_value' that increases by 'value_delta' at each step.
-    The last entry of the time series will be equal to 'start_value' + ('length' - 1) * 'value_delta'.
+    Creates a TimeSeries with a starting value of 'start_value' that increases linearly such that
+    it takes on the value 'end_value' at the last entry of the TimeSeries. This means that
+    the difference between two adjacent entries will be equal to 
+    ('end_value' - 'start_value') / ('length' - 1).
 
     :param start_value: The value of the first entry in the TimeSeries.
-    :param value_delta: The difference in value between to adjacent entries in the TimeSeries.
+    :param end_value: The value of the last entry in the TimeSeries.
     :param length: The length of the returned TimeSeries.
-    :param offset: The time differene between two adjacent entries in the returned TimeSeries. A DateOffset alias is expected.
-    :param start_date: The time index of the first entry in the returned TimeSeries.
-    :return: A linear TimeSeries with gradient 'value_delta'.
+    :param freq: The time difference between two adjacent entries in the returned TimeSeries. A DateOffset alias is expected.
+    :param start_ts: The time index of the first entry in the returned TimeSeries.
+    :return: A linear TimeSeries created as indicated above.
     """
 
-    times = pd.date_range(periods=length, freq=offset, start=start_date)
-    values = np.linspace(start_value, start_value + (length - 1) * value_delta, length)
+    times = pd.date_range(periods=length, freq=freq, start=start_ts)
+    values = np.linspace(start_value, end_value, length)
 
     return TimeSeries.from_times_and_values(times, values)
 
 
-def periodic_timeseries(frequency: float = 0.1, amplitude: float = 1, phase: float = 0, y_offset: float = 0,
-                        length: int = 10, offset: str = 'D',
-                        start_date: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
+def periodic_timeseries(value_frequency: float = 0.1, value_amplitude: float = 1, value_phase: float = 0, 
+                        value_y_offset: float = 0, length: int = 10, freq: str = 'D',
+                        start_ts: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
     """
     Creates a TimeSeries with a sinusoidal value progression with a given frequency, amplitude, phase and y offset.
 
-    :param frequency: The number of periods that take place within one time unit given in 'offset'.
-    :param amplitude: The maximum  difference between any value of the returned TimeSeries and 'y_offset'.
-    :param phase: The relative position within one period of the first value of the returned TimeSeries (in radians).
-    :param y_offset: The shift of the sine function along the y axis.
+    :param value_frequency: The number of periods that take place within one time unit given in 'freq'.
+    :param value_amplitude: The maximum  difference between any value of the returned TimeSeries and 'y_offset'.
+    :param value_phase: The relative position within one period of the first value of the returned TimeSeries (in radians).
+    :param value_y_offset: The shift of the sine function along the y axis.
     :param length: The length of the returned TimeSeries.
-    :param offset: The time differene between two adjacent entries in the returned TimeSeries. A DateOffset alias is expected.
-    :param start_date: The time index of the first entry in the returned TimeSeries.
+    :param freq: The time difference between two adjacent entries in the returned TimeSeries. A DateOffset alias is expected.
+    :param start_ts: The time index of the first entry in the returned TimeSeries.
     :return: A sinusoidal TimeSeries parametrized as indicated above.
     """
 
-    times = pd.date_range(periods=length, freq=offset, start=start_date)
+    times = pd.date_range(periods=length, freq=freq, start=start_ts)
     values = np.array(range(length), dtype=float)
-    f = np.vectorize(lambda x: amplitude * math.sin(2 * math.pi * frequency * x + phase) + y_offset)
+    f = np.vectorize(lambda x: value_amplitude * math.sin(2 * math.pi * value_frequency * x + value_phase) + value_y_offset)
     values = f(values)
 
     return TimeSeries.from_times_and_values(times, values)
 
 
-def white_noise_timeseries(length: int = 10, offset: str = 'D', mean: float = 0, std: float = 1,
-                           start_date: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
+def gaussian_timeseries(length: int = 10, freq: str = 'D', mean: float = 0, std: float = 1,
+                           start_ts: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
     """
-    Creates a white noise TimeSeries by sampling a gaussian distribution with mean 'mean' and 
-    standard deviation 'std'. Each value represents an indipendent sample of the distribution.
+    Creates a noise TimeSeries by sampling a gaussian distribution with mean 'mean' and 
+    standard deviation 'std'. Each value represents an independent sample of the distribution.
+    When the mean is set to 0, it can be considered a white noise TimeSeries.
 
     :param mean: The mean of the gaussian distribution that is sampled at each step.
     :param std: The standard deviation of the gaussian distribution that is sampled at each step.
     :param length: The length of the returned TimeSeries.
-    :param offset: The time differene between two adjacent entries in the returned TimeSeries. A DateOffset alias is expected.
-    :param start_date: The time index of the first entry in the returned TimeSeries.
+    :param freq: The time difference between two adjacent entries in the returned TimeSeries. A DateOffset alias is expected.
+    :param start_ts: The time index of the first entry in the returned TimeSeries.
     :return: A white noise TimeSeries created as indicated above.
     """
 
-    times = pd.date_range(periods=length, freq=offset, start=start_date)
+    times = pd.date_range(periods=length, freq=freq, start=start_ts)
     values = np.random.normal(mean, std, size=length)
 
     return TimeSeries.from_times_and_values(times, values)
 
 
-def random_walk_timeseries(length: int = 10, offset: str = 'D', mean: float = 0, std: float = 1,
-                           start_date: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
+def random_walk_timeseries(length: int = 10, freq: str = 'D', mean: float = 0, std: float = 1,
+                           start_ts: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
     """
     Creates a random walk TimeSeries by sampling a gaussian distribution with mean 'mean' and 
     standard deviation 'std'. The first value is one such random sample. Every subsequent value
@@ -102,12 +105,12 @@ def random_walk_timeseries(length: int = 10, offset: str = 'D', mean: float = 0,
     :param mean: The mean of the gaussian distribution that is sampled at each step.
     :param std: The standard deviation of the gaussian distribution that is sampled at each step.
     :param length: The length of the returned TimeSeries.
-    :param offset: The time differene between two adjacent entries in the returned TimeSeries. A DateOffset alias is expected.
-    :param start_date: The time index of the first entry in the returned TimeSeries.
+    :param freq: The time difference between two adjacent entries in the returned TimeSeries. A DateOffset alias is expected.
+    :param start_ts: The time index of the first entry in the returned TimeSeries.
     :return: A random walk TimeSeries created as indicated above.
     """
 
-    times = pd.date_range(periods=length, freq=offset, start=start_date)
+    times = pd.date_range(periods=length, freq=freq, start=start_ts)
     values = [np.random.normal(mean, std)]
     while (len(values) < length):
         values.append(values[-1] + np.random.normal(mean, std))
@@ -115,17 +118,17 @@ def random_walk_timeseries(length: int = 10, offset: str = 'D', mean: float = 0,
     return TimeSeries.from_times_and_values(times, values)
 
 
-def us_holiday_timeseries(length: int = 10, start_date: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
+def us_holiday_timeseries(length: int = 10, start_ts: pd.Timestamp = pd.Timestamp('2000-01-01')) -> 'TimeSeries':
     """
     Creates a binary TimeSeries that equals 1 at every index that corresponds to a US holiday, 
     and 0 otherwise. The frequency of the TimeSeries is daily.
 
     :param length: The length of the returned TimeSeries.
-    :param start_date: The time index of the first entry in the returned TimeSeries.
+    :param start_ts: The time index of the first entry in the returned TimeSeries.
     :return: Binary TimeSeries for US holidays.
     """
 
-    times = pd.date_range(periods=length, freq='D', start=start_date)
+    times = pd.date_range(periods=length, freq='D', start=start_ts)
     us_holidays = USFederalHolidayCalendar().holidays()
     values = times.isin(us_holidays).astype(int)
     


### PR DESCRIPTION
Implemented changes requested by Julien, including:
- changed the default value of constant_timeseries 
- renamed 'offset' to 'freq' and 'start_date' to 'start_ts' 
- improvements to docstrings 
- replaced parameter 'value_delta' with 'end_value' in linear_timeseries 
- made random_walk_timeseries more efficient 
- renamed white_noise_timeseries to gaussian_timeseries 
- added multivariate gaussian noise support
- renamed periodic_timeseries to sine_timeseries