### PR TITLE
fix(timeseries): missing legend when plotting

### DIFF
--- a/u8timeseries/timeseries.py
+++ b/u8timeseries/timeseries.py
@@ -403,7 +403,7 @@ class TimeSeries:
         Currently this is just a wrapper around pd.Series.plot()
         """
         fig = (plt.figure() if new_plot else plt.gcf())
-        self._series.plot(figure=fig)
+        self._series.plot(figure=fig, *args, **kwargs)
         x_label = self.time_index().name
         if x_label is not None and len(x_label) > 0:
             plt.xlabel(x_label)


### PR DESCRIPTION
Fixed missing legend by passing *args, **kwargs to pd.Series.plot(), which makes sure the 'label' argument gets passed on. This was important for other optional arguments too, such as 'lw'.