### PR TITLE
fix(logging): removed all custom_logging messages from unittest output

### DIFF
--- a/u8timeseries/custom_logging.py
+++ b/u8timeseries/custom_logging.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pathlib
 import time
 
-def get_logger(name: str):
+def get_logger(name: str, handler=logging.StreamHandler()):
     """
     Internally calls the logging.getLogger function with the 'name' argument to create or 
     retrieve a logger object. It is recommended to pass __name__ as argument when calling 
@@ -12,11 +12,11 @@ def get_logger(name: str):
     the messages appropriately.
 
     :param name: The name that gets passed to the logger.getLogger function.
+    :param handler: The handler instance to be added to the logger.
     :return: A logger instance with the given name.
     """
     logger = logging.getLogger(name)
     logger.setLevel(logging.INFO)
-    handler = logging.StreamHandler()
     formatter = logging.Formatter('[%(asctime)s] %(levelname)s | %(name)s | %(message)s')
     handler.setFormatter(formatter)
     logger.addHandler(handler)

--- a/u8timeseries/custom_logging.py
+++ b/u8timeseries/custom_logging.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pathlib
 import time
 
-def get_logger(name):
+def get_logger(name: str):
     """
     Internally calls the logging.getLogger function with the 'name' argument to create or 
     retrieve a logger object. It is recommended to pass __name__ as argument when calling 
@@ -16,10 +16,10 @@ def get_logger(name):
     """
     logger = logging.getLogger(name)
     logger.setLevel(logging.INFO)
-    stderr_handler = logging.StreamHandler()
+    handler = logging.StreamHandler()
     formatter = logging.Formatter('[%(asctime)s] %(levelname)s | %(name)s | %(message)s')
-    stderr_handler.setFormatter(formatter)
-    logger.addHandler(stderr_handler)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
     return logger
 
 def raise_if_not(condition: bool, message: str = "", logger: logging.Logger = get_logger('main_logger')):

--- a/u8timeseries/tests/test_autoregression_models.py
+++ b/u8timeseries/tests/test_autoregression_models.py
@@ -1,6 +1,7 @@
 import unittest
 import pandas as pd
 import numpy as np
+import logging
 
 from ..timeseries import TimeSeries
 from u8timeseries import Prophet, KthValueAgoBaseline, ExponentialSmoothing, TimeSeries, Arima, AutoArima
@@ -16,6 +17,9 @@ class ModelsTestCase(unittest.TestCase):
     values = np.sin(range(len(times))) + np.array([2.0] * len(times))
     ts: TimeSeries = TimeSeries.from_times_and_values(times, values)
 
+    @classmethod
+    def setUpClass(cls):
+        logging.disable(logging.CRITICAL)
 
     def test_autoregressive_models_runnability(self):
         models = [

--- a/u8timeseries/tests/test_logging.py
+++ b/u8timeseries/tests/test_logging.py
@@ -21,7 +21,7 @@ class LoggingTestCase(unittest.TestCase):
         exception_was_raised = False
         with LogCapture() as lc:
             logger = get_logger(__name__)
-            logger.handlers = [logging.NullHandler()]
+            logger.handlers = []
             try:
                 raise_log(Exception('test'), logger)
             except:
@@ -39,7 +39,7 @@ class LoggingTestCase(unittest.TestCase):
         exception_was_raised = False
         with LogCapture() as lc:
             logger = get_logger(__name__)
-            logger.handlers = [logging.NullHandler()]
+            logger.handlers = []
             try:
                 raise_if_not(True, "test", logger)
                 raise_if_not(False, "test", logger)
@@ -59,7 +59,7 @@ class LoggingTestCase(unittest.TestCase):
         times = pd.date_range(start='2000-01-01', periods=2, freq='D')
         values = np.array([1, 2])
         with LogCapture() as lc:
-            get_logger('u8timeseries.timeseries').handlers = [logging.NullHandler()]
+            get_logger('u8timeseries.timeseries').handlers = []
             try:
                 ts = TimeSeries.from_times_and_values(times, values)
             except:
@@ -75,7 +75,7 @@ class LoggingTestCase(unittest.TestCase):
         values = np.array(range(3))
         ts = TimeSeries.from_times_and_values(times, values)
         with LogCapture() as lc:
-            get_logger('u8timeseries.timeseries').handlers = [logging.NullHandler()]
+            get_logger('u8timeseries.timeseries').handlers = []
             try:
                 ts.split_after(pd.Timestamp('2020-02-01'))
             except:
@@ -90,7 +90,7 @@ class LoggingTestCase(unittest.TestCase):
         ts = constant_timeseries(length=100)
         model = Theta()
         with LogCapture() as lc:
-            get_logger('u8timeseries.models.theta').handlers = [logging.NullHandler()]
+            get_logger('u8timeseries.models.theta').handlers = []
             model.fit(ts)
         
         logged_message = lc.records[-1].getMessage()

--- a/u8timeseries/tests/test_logging.py
+++ b/u8timeseries/tests/test_logging.py
@@ -2,6 +2,7 @@ import unittest
 import pandas as pd
 import numpy as np
 import re
+import logging
 from testfixtures import LogCapture
 
 from ..timeseries import TimeSeries
@@ -12,10 +13,15 @@ from ..custom_logging import raise_log, raise_if_not, time_log, get_logger
 
 class LoggingTestCase(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        logging.disable(logging.NOTSET)
+
     def test_raise_log(self):
         exception_was_raised = False
         with LogCapture() as lc:
             logger = get_logger(__name__)
+            logger.handlers = [logging.NullHandler()]
             try:
                 raise_log(Exception('test'), logger)
             except:
@@ -33,6 +39,7 @@ class LoggingTestCase(unittest.TestCase):
         exception_was_raised = False
         with LogCapture() as lc:
             logger = get_logger(__name__)
+            logger.handlers = [logging.NullHandler()]
             try:
                 raise_if_not(True, "test", logger)
                 raise_if_not(False, "test", logger)
@@ -52,6 +59,7 @@ class LoggingTestCase(unittest.TestCase):
         times = pd.date_range(start='2000-01-01', periods=2, freq='D')
         values = np.array([1, 2])
         with LogCapture() as lc:
+            get_logger('u8timeseries.timeseries').handlers = [logging.NullHandler()]
             try:
                 ts = TimeSeries.from_times_and_values(times, values)
             except:
@@ -67,6 +75,7 @@ class LoggingTestCase(unittest.TestCase):
         values = np.array(range(3))
         ts = TimeSeries.from_times_and_values(times, values)
         with LogCapture() as lc:
+            get_logger('u8timeseries.timeseries').handlers = [logging.NullHandler()]
             try:
                 ts.split_after(pd.Timestamp('2020-02-01'))
             except:
@@ -81,6 +90,7 @@ class LoggingTestCase(unittest.TestCase):
         ts = constant_timeseries(length=100)
         model = Theta()
         with LogCapture() as lc:
+            get_logger('u8timeseries.models.theta').handlers = [logging.NullHandler()]
             model.fit(ts)
         
         logged_message = lc.records[-1].getMessage()

--- a/u8timeseries/tests/test_metrics.py
+++ b/u8timeseries/tests/test_metrics.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 import pandas as pd
+import logging
 
 from ..timeseries import TimeSeries
 from u8timeseries.metrics import metrics
@@ -16,6 +17,10 @@ class MetricsTestCase(unittest.TestCase):
     series0: TimeSeries = TimeSeries(pd_series1)
     series2: TimeSeries = TimeSeries(pd_series2)
     series3: TimeSeries = TimeSeries(pd_series3)
+
+    @classmethod
+    def setUpClass(cls):
+        logging.disable(logging.CRITICAL)
 
     def test_zero(self):
         self.assertTrue(np.isnan(metrics.mape(self.series1, self.series1)))

--- a/u8timeseries/tests/test_timeseries.py
+++ b/u8timeseries/tests/test_timeseries.py
@@ -1,6 +1,7 @@
 import unittest
 import pandas as pd
 import numpy as np
+import logging
 
 from ..timeseries import TimeSeries
 
@@ -14,6 +15,10 @@ class TimeSeriesTestCase(unittest.TestCase):
     series1: TimeSeries = TimeSeries(pd_series1)
     series2: TimeSeries = TimeSeries(pd_series1, pd_series2, pd_series3)
     series3: TimeSeries = TimeSeries(pd_series2)
+
+    @classmethod
+    def setUpClass(cls):
+        logging.disable(logging.CRITICAL)
 
     def test_creation(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Removed all custom_logging messages from unittest output by
1. Suppressing logging in all unittest files where log messages are printed.
2. Redirect log messages to NullHandler() for test_logging.py (logging cannot be suppressed here since we test for the right logging messages).