### PR TITLE
Move plotting dependencies as extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ and combine the predictions of several models and external regressors.
 ### pure pip
 This approach most likely requires other non-Python dependencies.
 
-```
+    # if plotting tweaks provided by u8timeseries are required
+    pip install .[plots]
+    # otherwise just
     pip install .
     # install any additional dev requirements, e.g.:
     pip install -r requirements/docs.txt
-```
 
 **Running the examples only without installing:**
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -2,9 +2,6 @@ numpy>=1.18.1
 scipy>=1.4.1
 statsmodels>=0.11.1
 pmdarima>=1.5.3
-matplotlib>=3.2.1
 fbprophet>=0.5
 pandas>=0.23.1
 tqdm>=4.32.1
-ipywidgets
-plotly>=4.6.0

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -5,3 +5,4 @@ pmdarima>=1.5.3
 fbprophet>=0.5
 pandas>=0.23.1
 tqdm>=4.32.1
+ipython>=7.13.0

--- a/requirements/plots.txt
+++ b/requirements/plots.txt
@@ -1,0 +1,3 @@
+matplotlib>=3.2.1
+ipywidgets
+plotly>=4.6.0

--- a/requirements/plots.txt
+++ b/requirements/plots.txt
@@ -1,3 +1,3 @@
 matplotlib>=3.2.1
-ipywidgets
+ipywidgets>=7.5.1
 plotly>=4.6.0

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
       license='Apache License 2.0',
       packages=find_packages(),
       install_requires=read_requirements('requirements/main.txt'),
+      extras_require={'plots': read_requirements('requirements/plots.txt')},
       zip_safe=False,
       python_requires='>=3.6',
       package_data={'u8timeseries': ['VERSION']}

--- a/u8timeseries/custom_logging.py
+++ b/u8timeseries/custom_logging.py
@@ -70,3 +70,11 @@ def time_log(logger: logging.Logger = get_logger('main_logger')):
         return timed
 
     return time_log_helper
+
+def try_import_matplotlib(logger: logging.Logger = get_logger('main_logger')):
+    try:
+        import matplotlib.pyplot as plt
+
+        return plt
+    except ImportError:
+        raise_log(ImportError('this method requires the optional package matplotlib to be installed'), logger)

--- a/u8timeseries/models/statistics.py
+++ b/u8timeseries/models/statistics.py
@@ -4,12 +4,11 @@ List of statistics.
 """
 
 from ..timeseries import TimeSeries
-from ..custom_logging import raise_log, get_logger
+from ..custom_logging import raise_log, get_logger, try_import_matplotlib
 import numpy as np
 from statsmodels.tsa.stattools import acf
 from scipy.stats import norm
 from statsmodels.tsa.seasonal import seasonal_decompose
-import matplotlib.pyplot as plt
 from typing import Tuple
 import math
 
@@ -194,6 +193,8 @@ def plot_acf(ts: 'TimeSeries', m: int = None, max_lag: int = 24, alpha: float = 
     stats = []
     for i in range(1, max_lag+1):
         stats.append(_bartlett_formula(r[1:], i, len(ts)))
+
+    plt = try_import_matplotlib(logger)
 
     plt.figure(figsize=fig_size)
 

--- a/u8timeseries/utils/missing_values.py
+++ b/u8timeseries/utils/missing_values.py
@@ -1,8 +1,10 @@
+from u8timeseries.custom_logging import get_logger, try_import_matplotlib
 from u8timeseries.timeseries import TimeSeries
-import matplotlib.pyplot as plt
 import numpy as np
 from typing import Tuple, List
 from scipy.interpolate import interp1d
+
+logger = get_logger(__name__)
 
 
 def na_ratio(ts: 'TimeSeries') -> float:
@@ -41,6 +43,8 @@ def nan_structure_visual(ts: 'TimeSeries', plot: bool = True) -> np.ndarray:
     nans = np.isnan(ts.values())
 
     if plot: # TODO: find a better way to visualize NaN data
+        plt = try_import_matplotlib(logger)
+
         plt.scatter(np.arange(len(nans)), nans)
         plt.yticks([0, 1], ["Non-missing", "NaN"])
         plt.show()


### PR DESCRIPTION
Plotting does not seem as a core functionality of u8timeseries (and it's just bloating our builds and dependencies) so mark them as optional/extra requirements, i.e. to make use also of plot stuff:

    pip install .[plots]

   instead of 

    pip install .

(and once published, `pip install u8timeseries[plots]`)

But everything else (so >95%) will still just work without them.

Notes
- like ~20s faster CI
- IPython and tqdm also seem optional? if that's the case, could add those as optional in the same extras bundle, e.g. `u8timeseries[visuals]`