### PR TITLE
Fix/suppress prophet logs

### DIFF
--- a/u8timeseries/custom_logging.py
+++ b/u8timeseries/custom_logging.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import os
 
 
 def get_logger(name: str, handler=logging.StreamHandler()):
@@ -70,3 +71,44 @@ def time_log(logger: logging.Logger = get_logger('main_logger')):
         return timed
 
     return time_log_helper
+
+
+class SuppressStdoutStderr(object):
+    '''
+    A context manager for doing a "deep suppression" of stdout and stderr in 
+    Python, i.e. will suppress all print, even if the print originates in a 
+    compiled C/Fortran sub-function.
+       This will not suppress raised exceptions, since exceptions are printed
+    to stderr just before a script exits, and after the context manager has
+    exited (at least, I think that is why it lets exceptions through).      
+
+    source: 
+    https://stackoverflow.com/questions/11130156/suppress-stdout-stderr-print-from-python-functions
+    '''
+    def __init__(self):
+        # Open a pair of null files
+        self.null_fds =  [os.open(os.devnull,os.O_RDWR) for x in range(2)]
+        # Save the actual stdout (1) and stderr (2) file descriptors.
+        self.save_fds = [os.dup(1), os.dup(2)]
+
+    def __enter__(self):
+        # Assign the null pointers to stdout and stderr.
+        os.dup2(self.null_fds[0],1)
+        os.dup2(self.null_fds[1],2)
+
+    def __exit__(self, *_):
+        # Re-assign the real stdout/stderr back to (1) and (2)
+        os.dup2(self.save_fds[0],1)
+        os.dup2(self.save_fds[1],2)
+        # Close all file descriptors
+        for fd in self.null_fds + self.save_fds:
+            os.close(fd)
+
+
+def execute_and_suppress_output(function, logger, suppression_threshold_level, *args):
+    if (logger.level >= suppression_threshold_level):
+        with SuppressStdoutStderr():
+            return_value = function(*args)
+    else:
+        return_value = function(*args)
+    return return_value

--- a/u8timeseries/custom_logging.py
+++ b/u8timeseries/custom_logging.py
@@ -108,7 +108,7 @@ class SuppressStdoutStderr(object):
 def execute_and_suppress_output(function, logger, suppression_threshold_level, *args):
     """
     This function conditionally executes the given function with the given arguments
-    based on whether the current level of 'logger' is below, above or equal to 
+    based on whether the current level of 'logger' is below, above or equal to
     'suppression_threshold_level'. In the latter two cases, all printouts to stdout
     and stderr will be suppressed.
 

--- a/u8timeseries/custom_logging.py
+++ b/u8timeseries/custom_logging.py
@@ -74,38 +74,50 @@ def time_log(logger: logging.Logger = get_logger('main_logger')):
 
 
 class SuppressStdoutStderr(object):
-    '''
-    A context manager for doing a "deep suppression" of stdout and stderr in 
-    Python, i.e. will suppress all print, even if the print originates in a 
+    """
+    A context manager for doing a "deep suppression" of stdout and stderr in
+    Python, i.e. will suppress all print, even if the print originates in a
     compiled C/Fortran sub-function.
        This will not suppress raised exceptions, since exceptions are printed
     to stderr just before a script exits, and after the context manager has
-    exited (at least, I think that is why it lets exceptions through).      
+    exited (at least, I think that is why it lets exceptions through).
 
-    source: 
+    source:
     https://stackoverflow.com/questions/11130156/suppress-stdout-stderr-print-from-python-functions
-    '''
+    """
     def __init__(self):
         # Open a pair of null files
-        self.null_fds =  [os.open(os.devnull,os.O_RDWR) for x in range(2)]
+        self.null_fds = [os.open(os.devnull, os.O_RDWR) for x in range(2)]
         # Save the actual stdout (1) and stderr (2) file descriptors.
         self.save_fds = [os.dup(1), os.dup(2)]
 
     def __enter__(self):
         # Assign the null pointers to stdout and stderr.
-        os.dup2(self.null_fds[0],1)
-        os.dup2(self.null_fds[1],2)
+        os.dup2(self.null_fds[0], 1)
+        os.dup2(self.null_fds[1], 2)
 
     def __exit__(self, *_):
         # Re-assign the real stdout/stderr back to (1) and (2)
-        os.dup2(self.save_fds[0],1)
-        os.dup2(self.save_fds[1],2)
+        os.dup2(self.save_fds[0], 1)
+        os.dup2(self.save_fds[1], 2)
         # Close all file descriptors
         for fd in self.null_fds + self.save_fds:
             os.close(fd)
 
 
 def execute_and_suppress_output(function, logger, suppression_threshold_level, *args):
+    """
+    This function conditionally executes the given function with the given arguments
+    based on whether the current level of 'logger' is below, above or equal to 
+    'suppression_threshold_level'. In the latter two cases, all printouts to stdout
+    and stderr will be suppressed.
+
+    :param function: Function whose printouts will conditionally be suppressed.
+    :param logger: Logger whose level will be checked.
+    :param suppression_threshold_level: Minimum logger level triggering suppression.
+    :param *args: Arguments passed to 'function'.
+    :return: Outputs of 'function'.
+    """
     if (logger.level >= suppression_threshold_level):
         with SuppressStdoutStderr():
             return_value = function(*args)

--- a/u8timeseries/models/prophet.py
+++ b/u8timeseries/models/prophet.py
@@ -11,7 +11,7 @@ from ..custom_logging import time_log, get_logger, execute_and_suppress_output
 import logging
 
 logger = get_logger(__name__)
-logger.level = logging.WARNING # set to warning to suppress prophet logs
+logger.level = logging.WARNING  # set to warning to suppress prophet logs
 
 
 class Prophet(AutoRegressiveModel):
@@ -79,7 +79,6 @@ class Prophet(AutoRegressiveModel):
             self.model.add_country_holidays(self.country_holidays)
 
         execute_and_suppress_output(self.model.fit, logger, logging.WARNING, in_df)
-
 
     def predict(self, n):
         super().predict(n)

--- a/u8timeseries/models/prophet.py
+++ b/u8timeseries/models/prophet.py
@@ -7,9 +7,11 @@ import fbprophet
 import pandas as pd
 
 from u8timeseries.models.autoregressive_model import AutoRegressiveModel
-from ..custom_logging import time_log, get_logger
+from ..custom_logging import time_log, get_logger, execute_and_suppress_output
+import logging
 
 logger = get_logger(__name__)
+logger.level = logging.WARNING # set to warning to suppress prophet logs
 
 
 class Prophet(AutoRegressiveModel):
@@ -76,7 +78,8 @@ class Prophet(AutoRegressiveModel):
         if self.country_holidays is not None:
             self.model.add_country_holidays(self.country_holidays)
 
-        self.model.fit(in_df)
+        execute_and_suppress_output(self.model.fit, logger, logging.WARNING, in_df)
+
 
     def predict(self, n):
         super().predict(n)


### PR DESCRIPTION
- Added a function that conditionally suppresses all stdout and stderr messages depending on the level of the logger and a given severity threshold.
- Used this function to suppress fbprophet logs created by the fit function.