### PR TITLE
Add test coverage

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -38,9 +38,10 @@ jobs:
           pip install -q .
           pip install -q -r requirements/dev.txt
 
-      - name: "5. Run tests"
+      - name: "5. Run tests with coverage"
         run: |
-          python -m unittest
+          coverage run -m unittest
+          coverage report -m --fail-under=80
 
       - name: "6. Run linter"
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ dist/
 examples/.ipynb_checkpoints/
 runs/
 .coverage
+htmlcov
 
 docs_env

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ build/
 dist/
 examples/.ipynb_checkpoints/
 runs/
+.coverage
 
 docs_env

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,6 @@
 # tests
 testfixtures>=6.14.0
+coverage>=5.1
 
 # linters
 flake8>=3.7.9


### PR DESCRIPTION
Fails if coverage <80%, currently 84%

These could use some tests:

    Name                                                 Stmts   Miss  Cover   Missing
    u8timeseries\backtesting\backtesting_udf.py             28     20    29%   37-60, 83-88
    u8timeseries\backtesting\forecasting_simulation.py      52     40    23%   43-70, 97-131
    u8timeseries\metrics\metrics.py                         80     34    58%   18-22, 44-47, 59-62, 74, 87-89, 101, 121, 135-141, 158-162, 165, 189, 208, 226
    u8timeseries\models\statistics.py                       76     25    67%   38, 41, 59-60, 76, 90, 103, 137-138, 143, 176-180, 194-212
    u8timeseries\utils\utils.py                             29     17    41%   22-28, 40-49, 52-55
    ...
    ----------------------------------------------------------------------------------
    TOTAL                                                 2069    327    84%

Notes:
1. Locally can also generate html report with nice highlighting:

        coverage html

2. Could also try [coveralls](https://coveralls.io/) for badge, but it's an external service; iirc it uses the same coverage code internally.